### PR TITLE
Fix stride issues in flash_attn_interface

### DIFF
--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -238,7 +238,7 @@ class FlashAttnFunc(torch.autograd.Function):
     @staticmethod
     def backward(ctx, dout, *args):
         q, k, v, out, softmax_lse, rng_state = ctx.saved_tensors
-        dq, dk, dv = torch.empty_strided(q.size(),q.stride(), dtype=q.dtype, device=q.device), torch.empty_strided(k.size(), k.stride(), dtype=k.dtype, device=k.device), torch.empty_strided(v.size(), v.stride(), dtype=v.dtype, device=v.device)
+        dq, dk, dv = torch.empty_like(q), torch.empty_like(k), torch.empty_like(v)
         _flash_attn_backward(
             dout, q, k, v, out, softmax_lse,
             dq, dk, dv, ctx.dropout_p, ctx.softmax_scale, ctx.causal,

--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -60,9 +60,15 @@ def _flash_attn_varlen_forward(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q
 
 def _flash_attn_backward(dout, q, k, v, out, softmax_lse, dq, dk, dv,
                          dropout_p, softmax_scale, causal, rng_state=None):
-    maybe_contiguous = lambda x: x.contiguous() if x.stride(-1) != 1 else x
+    maybe_contiguous = lambda x: x.contiguous() if not x.is_contiguous() else x
     # dq, dk, dv are allocated by us so they should already be contiguous
     dout, q, k, v, out = [maybe_contiguous(x) for x in (dout, q, k, v, out)]
+    
+    if out.stride() != dout.stride():
+        out = out.as_strided(dout.size(),dout.stride())
+    if dq.stride() != q.stride():
+        dq = dq.as_strided(q.size(),q.stride())
+        
     dq, dk, dv, softmax_d, = flash_attn_cuda.bwd(
         dout, q, k, v, out, softmax_lse, dq, dk, dv, dropout_p,
         softmax_scale, causal, None, rng_state
@@ -73,7 +79,7 @@ def _flash_attn_backward(dout, q, k, v, out, softmax_lse, dq, dk, dv,
 def _flash_attn_varlen_backward(dout, q, k, v, out, softmax_lse, dq, dk, dv,
                                 cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k,
                                 dropout_p, softmax_scale, causal, rng_state=None):
-    maybe_contiguous = lambda x: x.contiguous() if x.stride(-1) != 1 else x
+    maybe_contiguous = lambda x: x.contiguous() if not x.is_contiguous() else x
     # dq, dk, dv are allocated by us so they should already be contiguous
     dout, q, k, v, out = [maybe_contiguous(x) for x in (dout, q, k, v, out)]
     dq, dk, dv, softmax_d, = flash_attn_cuda.varlen_bwd(
@@ -232,7 +238,7 @@ class FlashAttnFunc(torch.autograd.Function):
     @staticmethod
     def backward(ctx, dout, *args):
         q, k, v, out, softmax_lse, rng_state = ctx.saved_tensors
-        dq, dk, dv = torch.empty_like(q), torch.empty_like(k), torch.empty_like(v)
+        dq, dk, dv = torch.empty_strided(q.size(),q.stride(), dtype=q.dtype, device=q.device), torch.empty_strided(k.size(), k.stride(), dtype=k.dtype, device=k.device), torch.empty_strided(v.size(), v.stride(), dtype=v.dtype, device=v.device)
         _flash_attn_backward(
             dout, q, k, v, out, softmax_lse,
             dq, dk, dv, ctx.dropout_p, ctx.softmax_scale, ctx.causal,


### PR DESCRIPTION
### What:
Ensures tensors are contiguous in memory with matching strides during the backward pass.

Fixes #40

### Why: 
Multiple users/customers have been facing issues while training with the axolotl package see #40

`maybe_contiguous` fails to adequately check if tensors are contiguous in certain packing scenarios

### Changes:

- **flash_attn_interface.py**
    - _flash_attn_backward: stride check, contiguous check
    - _flash_attn_varlen_backward: contiguous check

### Testing:
- **Manual testing:** Successfully fine tuned Phi-2, StableLM, and TinyLlama in axolotl
- **Automated testing:** Benchmarking scripts ran as expected