### PR TITLE
Update fake tensor wrapper for flash_attn and falash_attn_varlen_func…

### DIFF
--- a/tests/test_flash_attn_ck.py
+++ b/tests/test_flash_attn_ck.py
@@ -302,8 +302,9 @@ def test_flash_attn_varlen_qkvpacked(seqlen, d, dropout_p, causal, local, alibi,
     ],
 )
 @pytest.mark.parametrize("dropout_p", [0.0, 0.17])
+@pytest.mark.parametrize("compiled", [False, True])
 def test_flash_attn_output(
-    seqlen_q, seqlen_k, d, dropout_p, causal, local, alibi, deterministic, mha_type, dtype, kvpacked
+    seqlen_q, seqlen_k, d, dropout_p, causal, local, alibi, deterministic, mha_type, dtype, kvpacked, compiled
 ):
     device = "cuda"
     # set seed
@@ -343,7 +344,8 @@ def test_flash_attn_output(
             return_attn_probs=True,
         )
     else:
-        out, lse, S_dmask = flash_attn_func(
+        flash_func = torch.compile(flash_attn_func) if compiled else flash_attn_func
+        out, lse, S_dmask = flash_func(
             q,
             k,
             v,
@@ -519,8 +521,9 @@ def test_flash_attn_output(
     ],
 )
 @pytest.mark.parametrize("dropout_p", [0.0, 0.17])
+@pytest.mark.parametrize("compiled", [False, True])
 def test_flash_attn_varlen_output(
-    seqlen_q, seqlen_k, d, dropout_p, causal, local, alibi, deterministic, mha_type, dtype, kvpacked
+    seqlen_q, seqlen_k, d, dropout_p, causal, local, alibi, deterministic, mha_type, dtype, kvpacked, compiled
 ):
     device = "cuda"
     # set seed
@@ -598,7 +601,8 @@ def test_flash_attn_varlen_output(
             dq_pad_fn,
             dk_pad_fn,
         ) = generate_qkv(q, k, v, query_padding_mask, key_padding_mask, kvpacked=False)
-        out_unpad, sm_lse, S_dmask = flash_attn_varlen_func(
+        flash_varlen_func = torch.compile(flash_attn_varlen_func) if compiled else flash_attn_varlen_func
+        out_unpad, sm_lse, S_dmask = flash_varlen_func(
             q_unpad,
             k_unpad,
             v_unpad,


### PR DESCRIPTION
Updates the fake tensor wrapper function to make `flash_attn_func` and `flash_attn_varlen_func` compatible with torch compile. Without the update `torch.compile(flash_attn_func)` throws "wrong number of dimensions" error because the bwd pass returns a 3d tensor when the fake tensor wrapper expects a 2d tensor. The details of the errors are reported in SWDEV-559708, SWDEV-546369, SWDEV-559718. 

`test_flash_attn_output` and `test_flash_attn_varlen_output` are extended to test both the eager and compiled versions of the function with the help of a Boolean parameter called `compiled`. Here are the results of the test 
- Reference results in Eager mode
   - flash_attn_func : 42240 passed, 1 warning
   - flash_attn_varlen_func: 46464 passed, 1 warning
- Compiled FA results without the patch
  - flash_attn_func : 10 failed, 42230 passed, 1 warning
  - flash_attn_varlen_func: 10 failed, 46454 passed, 1 warning
- Compiled FA results with patch
   - flash_attn_func : 42240 passed, 1 warning
   -  flash_attn_varlen_func: 46464 passed, 1 warning


## Motivation

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
