### PR TITLE
Enable all gfx11 targets

### DIFF
--- a/flash_attn/flash_attn_triton_amd/fwd_prefill.py
+++ b/flash_attn/flash_attn_triton_amd/fwd_prefill.py
@@ -93,12 +93,9 @@ def get_fwd_configs(autotune: bool):
                 )
         elif arch in (
             "gfx1030",
-            "gfx1100",
-            "gfx1101",
-            "gfx1102",
             "gfx1200",
             "gfx1201",
-        ):  # RDNA architectures
+        ) or arch.startswith("gfx11"):  # RDNA architectures
             configs.append(
                 triton.Config(
                     {

--- a/flash_attn/flash_attn_triton_amd/utils.py
+++ b/flash_attn/flash_attn_triton_amd/utils.py
@@ -1501,11 +1501,9 @@ def is_cdna():
 
 @functools.cache
 def is_rdna():
-    return is_hip() and get_arch() in (
+    arch = get_arch()
+    return is_hip() and (arch in (
         "gfx1030",
-        "gfx1100",
-        "gfx1101",
-        "gfx1102",
         "gfx1200",
         "gfx1201",
-    )
+    ) or arch.startswith("gfx11"))


### PR DESCRIPTION
## Motivation

Enable all gfx11, in particular gfx1103, gfx1150, gfx1151, gfx1152 and gfx1153.

Should this go to the upstream repository directly?

## Technical Details

Those are all RDNA 3 / RDNA 3.5 and are very similar.

## Test Plan

Tested in gfx1151:
`FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" pytest tests/test_flash_attn_triton_amd.py`

## Test Result



## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
