### PR TITLE
Fix Windows import errors by guarding `torch.distributed` with `hasattr` checks

### DIFF
--- a/flash_attn/utils/distributed.py
+++ b/flash_attn/utils/distributed.py
@@ -8,9 +8,9 @@ from torch.distributed import ProcessGroup
 # `_all_gather_base` and `_reduce_scatter_base`. They require the most recent
 # version of PyTorch. The following 4 lines are for backward compatibility with
 # older PyTorch.
-if "all_gather_into_tensor" not in dir(torch.distributed):
+if "all_gather_into_tensor" not in dir(torch.distributed) and hasattr(torch.distributed, "_all_gather_base"):
     torch.distributed.all_gather_into_tensor = torch.distributed._all_gather_base
-if "reduce_scatter_tensor" not in dir(torch.distributed):
+if "reduce_scatter_tensor" not in dir(torch.distributed) and hasattr(torch.distributed, "_reduce_scatter_base"):
     torch.distributed.reduce_scatter_tensor = torch.distributed._reduce_scatter_base
 
 


### PR DESCRIPTION
## Motivation

On Windows ROCm, `torch.distributed` does not expose certain internal attributes (e.g. `_all_gather_base`).
This causes an `AttributeError` during import in `flash_attn.utils.distributed`.

Example (when loading a custom node in ComfyUI):
```
  File "E:\ComfyUI\venv\Lib\site-packages\flash_attn\utils\distributed.py", line 12, in <module>
    torch.distributed.all_gather_into_tensor = torch.distributed._all_gather_base
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'torch.distributed' has no attribute '_all_gather_base'

Cannot import E:\ComfyUI\custom_nodes\RES4LYF module for custom nodes: module 'torch.distributed' has no attribute '_all_gather_base'
```

This PR guards access to these attributes using `hasattr` checks, preventing the import failure.

This change is not expected to affect Linux behavior.

## Technical Details

Adds hasattr checks before accessing private `torch.distributed` attributes in `flash_attn.utils.distributed`.

This improves ROCm compatibility for FlashAttention-2 on Windows.

### Specifications:
OS: Windows 11
GPU: AMD Radeon RX 9060 XT (gfx1200)
Python: 3.12.10
PyTorch: 2.12.0a0+rocm7.12.0a20260218 ([TheRock](https://github.com/ROCm/TheRock))
Triton: 3.6.0a0.post25 ([triton-windows](https://github.com/woct0rdho/triton-windows))


## Test Plan

- Functional testing on AMD Radeon RX 9060 XT (gfx1200)

- Verified that FlashAttention-2 loads successfully

- Ran existing Triton Flash Attention tests

## Test Result

All existing Triton Flash Attention tests pass on gfx1200.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
