### PR TITLE
add zero_tensors option with default False to flash_attn_varlen_func api

### DIFF
--- a/flash_attn/flash_attn_interface.py
+++ b/flash_attn/flash_attn_interface.py
@@ -921,6 +921,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         return_softmax,
         block_table,
         is_grad_enabled,
+        zero_tensors: bool = False, 
     ):
         is_grad = is_grad_enabled and any(
             x.requires_grad for x in [q, k, v]
@@ -949,6 +950,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             alibi_slopes=alibi_slopes,
             return_softmax=return_softmax and dropout_p > 0,
             block_table=block_table,
+            zero_tensors = zero_tensors,
         )
         if is_grad:
             ctx.save_for_backward(
@@ -963,6 +965,7 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             ctx.softcap = softcap
             ctx.alibi_slopes = alibi_slopes
             ctx.deterministic = deterministic
+            ctx.zero_tensors = zero_tensors
 
         out = out_padded[..., :head_size_og]
         return out if not return_softmax else (out, softmax_lse, S_dmask)
@@ -998,11 +1001,12 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
             ctx.alibi_slopes,
             ctx.deterministic,
             rng_state=rng_state,
+            zero_tensors = ctx.zero_tensors
         )
         dq = dq[..., : dout.shape[-1]]  # We could have padded the head dimension
         dk = dk[..., : dout.shape[-1]]
         dv = dv[..., : dout.shape[-1]]
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 def flash_attn_qkvpacked_func(
@@ -1394,6 +1398,7 @@ def flash_attn_varlen_func(
     deterministic=False,
     return_attn_probs=False,
     block_table=None,
+    zero_tensors = False,
 ):
     """dropout_p should be set to 0.0 during evaluation
     Supports multi-query and grouped-query attention (MQA/GQA) by passing in K, V with fewer heads
@@ -1468,6 +1473,7 @@ def flash_attn_varlen_func(
         return_attn_probs,
         block_table,
         torch.is_grad_enabled(),
+        zero_tensors,
     )
 
 


### PR DESCRIPTION
## Motivation

TransformerEngine (TE) integrate flash-attn as one of the attn backends. For the varlen mode in TE, users can create q, k, v with a fixed total_seqlen larger than the cu_seqlen[-1]. Therefore the padding area for O, dQ, dK, dV, from [cu_seqlen[-1]: end] is undefined since we allocate those tensors with torch.empty_like(). Undefined tensors in the padding area can affect the subsequent bwd operations in transformer model. In addition, on NV h100, torch.empty_like already returns zeroed-out tensors.

Therefore we propose an extra zero_tensors option with default value False into api flash_attn_varlen_func. For customers who creates q/k/v with fixed length, we pass this option into ck kernels so that they can zero out padding areas in the output. This won't affect the original default behavior

## Technical Details

Add the zero_tensors option into flash_attn_varlen_func api

## Test Plan

Will test flash-attn CI and TE CI

## Test Result

TE CI passed
Flash-attn CI pending

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
