### PR TITLE
[CK_TILE] Fix NaN for FMHA BWD When seq_q=0

### DIFF
--- a/tests/test_flash_attn_ck.py
+++ b/tests/test_flash_attn_ck.py
@@ -1556,7 +1556,7 @@ def test_flash_attn_bwd_varlen_overflow(d, causal, dtype):
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("d", [64, 128])
 def test_flash_attn_bwd_varlen_seqq_zero(d, causal, nheads_kv, deterministic, dtype):
-    """Regression test: NaN in dK/dV for the zero-length Q subsequence when using GQA.
+    """Regression test: NaN in dK/dV for the zero-length Q subsequence (run for both GQA and MHA).
     """
     if not is_bwd_supported(d, deterministic=deterministic):
         pytest.skip(get_bwd_unsupported_reason(d, deterministic=deterministic))
@@ -1589,7 +1589,11 @@ def test_flash_attn_bwd_varlen_seqq_zero(d, causal, nheads_kv, deterministic, dt
     assert not k.grad.isnan().any()
     assert not v.grad.isnan().any()
 
-
+    # Additionally, for the batch with seqlen_q == 0, the corresponding K/V segment
+    # should contribute nothing to the loss, so dK/dV for that segment must be zero.
+    end_kv_zero = int(k_cuseqlen[1])
+    assert k.grad[:end_kv_zero].abs().max() == 0
+    assert v.grad[:end_kv_zero].abs().max() == 0
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("local", [False, True])
 @pytest.mark.parametrize("causal", [False, True])

--- a/tests/test_flash_attn_ck.py
+++ b/tests/test_flash_attn_ck.py
@@ -1594,6 +1594,8 @@ def test_flash_attn_bwd_varlen_seqq_zero(d, causal, nheads_kv, deterministic, dt
     end_kv_zero = int(k_cuseqlen[1])
     assert k.grad[:end_kv_zero].abs().max() == 0
     assert v.grad[:end_kv_zero].abs().max() == 0
+
+
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("local", [False, True])
 @pytest.mark.parametrize("causal", [False, True])

--- a/tests/test_flash_attn_ck.py
+++ b/tests/test_flash_attn_ck.py
@@ -1551,6 +1551,46 @@ def test_flash_attn_bwd_varlen_overflow(d, causal, dtype):
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("deterministic", [False, True])
+@pytest.mark.parametrize("nheads_kv", [1, 8])  # GQA (1) and MHA (8)
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("d", [64, 128])
+def test_flash_attn_bwd_varlen_seqq_zero(d, causal, nheads_kv, deterministic, dtype):
+    """Regression test: NaN in dK/dV for the zero-length Q subsequence when using GQA.
+    """
+    if not is_bwd_supported(d, deterministic=deterministic):
+        pytest.skip(get_bwd_unsupported_reason(d, deterministic=deterministic))
+
+    device = "cuda"
+    torch.random.manual_seed(0)
+    nheads = 8  # n_q_heads; GQA when nheads_kv < nheads
+    q_cuseqlen = torch.tensor([0, 0, 256, 512], device=device, dtype=torch.int32)
+    k_cuseqlen = torch.tensor([0, 503, 768, 1536], device=device, dtype=torch.int32)
+    total_q = int(q_cuseqlen[-1])   # 512
+    total_k = int(k_cuseqlen[-1])   # 1536
+    Mq = 256
+    Mk = 768
+
+    q = torch.randn([total_q, nheads, d], dtype=dtype, device=device)
+    k = torch.randn([total_k, nheads_kv, d], dtype=dtype, device=device)
+    v = torch.randn([total_k, nheads_kv, d], dtype=dtype, device=device)
+    q.requires_grad_(True)
+    k.requires_grad_(True)
+    v.requires_grad_(True)
+
+    out = flash_attn_varlen_func(
+        q, k, v, q_cuseqlen, k_cuseqlen, Mq, Mk, causal=causal, deterministic=deterministic
+    )
+    g = torch.randn_like(out)
+    out.backward(g)
+
+    # The bug produced NaN specifically in dK/dV for the zero-length Q subsequence
+    assert not q.grad.isnan().any()
+    assert not k.grad.isnan().any()
+    assert not v.grad.isnan().any()
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("local", [False, True])
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("d", [32, 40, 59, 64, 80, 96, 111, 128, 160, 192, 224, 256])


### PR DESCRIPTION
## Motivation

When the variable-length FMHA backward pass encounters a batch entry whose query sequence length is zero (`seqlen_q == 0`), the CK_TILE backward pipelines could produce **NaN values in dK and dV**.

The fix and its follow-ons form a chain of three PRs:

1. **Root cause: early exit without zeroing accumulators** (ROCm/rocm-libraries#5790) — the dK/dV pipelines did not exit early when `num_total_loop <= 0`, so accumulator registers with random values were written out as gradients. The group-mode kernel also returned early when `seqlen_q == 0`, preventing the zeroed dK/dV from ever being stored.

2. **Exposed by fix 1: VGPR spill / register reuse** (ROCm/rocm-libraries#5915) — once the early-exit path was added, `num_total_loop` was computed without `amd_wave_read_first_lane()`, so the compiler treated it as a VGPR even though it is uniform across all lanes. Under the resulting register pressure the compiler reused `v52:v53` as both a B-matrix input for dK MFMAs and a temporary for dV, producing silently wrong gradients.

3. **Also exposed by fix 1: AGPR misallocation in the IGLP pipeline** (ROCm/rocm-libraries#5991) — the CFG change from fix 1 caused the LLVM register allocator to reuse AGPR accumulators as scratch space in the dK/dV reduction loop on MI350. Adding `[[unlikely]]` to the early-exit branch restores the expected CFG so AGPRs are correctly allocated per accumulator column.

## Changes

- **`csrc/composable_kernel`** — bump submodule to `791afc646` (ROCm/rocm-libraries#5991), which includes all three fixes above on top of the existing `ck_improve_main` baseline.
- **`tests/test_flash_attn_ck.py`** — add `test_flash_attn_bwd_varlen_seqq_zero`, a regression test that constructs a 3-batch varlen backward pass where the first batch entry has `seqlen_q == 0` and asserts that no NaN appears in dQ, dK, or dV. Parametrized over dtype (fp16/bf16), causal, nheads_kv (GQA/MHA), and head dim (64, 128).

## Test Plan

```
pytest tests/test_flash_attn_ck.py::test_flash_attn_bwd_varlen_seqq_zero -v
pytest tests/test_flash_attn_ck.py -x  # full suite
```

## Test Results

The new regression test passes on MI300X. The full backward test suite (`test_flash_attn_bwd_*`) shows no regressions, including causal, non-causal, GQA, MHA, deterministic, and sliding-window variants.