### PR TITLE
feat: add gfx908 (MI100) to allowed CK build architectures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ def rename_cpp_to_cu(cpp_files):
 
 def validate_and_update_archs(archs):
     # List of allowed architectures
-    allowed_archs = ["native", "gfx90a", "gfx942", "gfx950", "gfx1100", "gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200", "gfx1201"]
+    allowed_archs = ["native", "gfx908", "gfx90a", "gfx942", "gfx950", "gfx1100", "gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1200", "gfx1201"]
 
     # Validate if each element in archs is in allowed_archs
     assert all(


### PR DESCRIPTION
## Summary

Add `gfx908` (AMD Instinct MI100, CDNA1) to the `allowed_archs` list in `setup.py`, enabling the CK flash attention backend to be built for MI100 GPUs.

## Why this works

gfx908 shares the MFMA instruction set with gfx90a (CDNA2) and routes through the same `KernelComponentFactoryGfx9` codegen path in CK. Specifically:

- `__builtin_amdgcn_mfma_f32_16x16x16f16` is available on gfx908
- `buffer_load_dword` with LDS direct store (`llvm.amdgcn.raw.buffer.load.lds`) is supported
- `warp_gemm_attribute_mfma_impl.hpp` already has explicit `#elif defined(__gfx908__)` paths for BF16 MFMA emulation
- `arch.hpp` already maps `"gfx908"` to `GFX908` target ID

The only blocker was the `allowed_archs` validation in `setup.py`.

## VGPR/AGPR concern

gfx908 has 256 VGPRs but no AGPRs (gfx90a adds 256 AGPRs for MFMA accumulators). Despite this, the 128x128x32 tiles with hdim=128 compile cleanly with **no register spilling** on gfx908 with ROCm 7.2 hipcc.

## Testing

Tested on 4x MI100 (gfx908:sramecc+:xnack-) with ROCm 7.2 / PyTorch 2.11:

- **Build**: All 718 CK kernels (hdim=128, receipt=2) compile without errors or register spill warnings
- **Correctness**: `flash_attn_varlen_func` produces correct outputs (no NaN/Inf, sensible value range)
- **Performance**: 34% of peak MFMA FP16 throughput at 32k sequence length (63 TFLOPS on single MI100)

| SeqLen | CK (ms) | TFLOPS | % of 184.6 TFLOPS peak |
|--------|---------|--------|----------------------|
| 2048   | 0.33    | 26.4   | 14.3%                |
| 8192   | 2.24    | 61.3   | 33.2%                |
| 16384  | 8.78    | 62.6   | 33.9%                |
| 32768  | 34.71   | 63.4   | 34.3%                |

## Change

One-line addition of `"gfx908"` to the `allowed_archs` list.

AI assistance was used (Claude). All changes reviewed and tested on hardware.
