### PR TITLE
[CK_TILE] FMHA BWD: stream-async workspace prepare

### DIFF
--- a/csrc/flash_attn_ck/mha_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_bwd.cpp
@@ -349,7 +349,23 @@ mha_bwd(const at::Tensor &dout,                   // batch_size x seqlen_q x num
         workspace = torch::empty({static_cast<int64_t>(launcher.workspace_size)},
                                  opts.dtype(at::kByte));
         workspace_ptr = workspace.data_ptr();
-        launcher.prepare_workspace(workspace_ptr);
+        // Pinned host buffer allocator backed by PyTorch's CachingHostAllocator.
+        // The returned shared_ptr owns the at::Tensor; the launcher keeps it
+        // alive via a stream-tail hipLaunchHostFunc keepalive. Required when
+        // the launcher needs host-side workspace metadata (deterministic mode
+        // and/or non-trivial worker state); harmless when it doesn't.
+        auto pinned_host_alloc = [](size_t bytes) -> std::shared_ptr<void> {
+            auto t = std::make_shared<at::Tensor>(torch::empty(
+                {static_cast<int64_t>(bytes)},
+                torch::TensorOptions().dtype(at::kByte).pinned_memory(true)));
+            return std::shared_ptr<void>(t, t->data_ptr());
+        };
+        ck_tile::stream_config prep_cfg{stream};
+        launcher.prepare_workspace_async(workspace_ptr,
+                                         /*seqstart_q_dev=*/nullptr,
+                                         /*seqstart_k_dev=*/nullptr,
+                                         prep_cfg,
+                                         pinned_host_alloc);
     }
 
     at::Tensor dk_expanded, dv_expanded;

--- a/csrc/flash_attn_ck/mha_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_bwd.cpp
@@ -357,7 +357,7 @@ mha_bwd(const at::Tensor &dout,                   // batch_size x seqlen_q x num
         auto pinned_host_alloc = [](size_t bytes) -> std::shared_ptr<void> {
             auto t = std::make_shared<at::Tensor>(torch::empty(
                 {static_cast<int64_t>(bytes)},
-                torch::TensorOptions().dtype(at::kByte).pinned_memory(true)));
+                torch::TensorOptions().dtype(at::kByte).device(at::kCPU).pinned_memory(true)));
             return std::shared_ptr<void>(t, t->data_ptr());
         };
         ck_tile::stream_config prep_cfg{stream};

--- a/csrc/flash_attn_ck/mha_varlen_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_varlen_bwd.cpp
@@ -373,7 +373,7 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
         auto pinned_host_alloc = [](size_t bytes) -> std::shared_ptr<void> {
             auto t = std::make_shared<at::Tensor>(torch::empty(
                 {static_cast<int64_t>(bytes)},
-                torch::TensorOptions().dtype(at::kByte).pinned_memory(true)));
+                torch::TensorOptions().dtype(at::kByte).device(at::kCPU).pinned_memory(true)));
             return std::shared_ptr<void>(t, t->data_ptr());
         };
         ck_tile::stream_config prep_cfg{stream};

--- a/csrc/flash_attn_ck/mha_varlen_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_varlen_bwd.cpp
@@ -19,9 +19,7 @@ fmha_bwd_traits get_ck_fmha_varlen_bwd_traits(const mask_info &mask,
                                               int nhead_k,
                                               bool has_dropout,
                                               bool enable_alibi,
-                                              bool deterministic,
-                                              const int* seqstart_qs,
-                                              const int* seqstart_ks)
+                                              bool deterministic)
 {
     return fmha_bwd_traits{seqlen_q,
                            seqlen_k,
@@ -39,9 +37,7 @@ fmha_bwd_traits get_ck_fmha_varlen_bwd_traits(const mask_info &mask,
                            false,    // has_dbias
                            has_dropout,
                            false, // s_randval
-                           deterministic,
-                           seqstart_qs,
-                           seqstart_ks};
+                           deterministic};
 }
 fmha_bwd_args get_ck_fmha_varlen_bwd_args(const mask_info &mask,
                                           // sizes
@@ -339,11 +335,6 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
         dv = torch::empty_like(v);
     }
 
-    // seqstart_qs/ks are dereferenced on the HOST inside fmha_bwd_launcher constructor
-    // (to compute workspace sizes), so we must use host copies.
-    at::Tensor cu_seqlens_q_host = cu_seqlens_q.cpu();
-    at::Tensor cu_seqlens_k_host = cu_seqlens_k.cpu();
-
     const auto traits = get_ck_fmha_varlen_bwd_traits(
         mask,
         q_dtype_str,
@@ -357,9 +348,7 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
         num_heads_k,
         is_dropout,
         alibi_slopes_.has_value(),
-        deterministic,
-        reinterpret_cast<const int*>(cu_seqlens_q_host.data_ptr()),
-        reinterpret_cast<const int*>(cu_seqlens_k_host.data_ptr()));
+        deterministic);
     fmha_bwd_launcher launcher(traits);
 
     at::cuda::CUDAGuard device_guard{q.device()};
@@ -377,7 +366,23 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
         workspace = torch::empty({static_cast<int64_t>(launcher.workspace_size)},
                                  opts.dtype(at::kByte));
         workspace_ptr = workspace.data_ptr();
-        launcher.prepare_workspace(workspace_ptr);
+        // Pinned host buffer allocator backed by PyTorch's CachingHostAllocator.
+        // The returned shared_ptr owns the at::Tensor; the launcher keeps it
+        // alive via a stream-tail hipLaunchHostFunc keepalive so the buffer
+        // is not recycled while async D2H/H2D copies are still in flight.
+        auto pinned_host_alloc = [](size_t bytes) -> std::shared_ptr<void> {
+            auto t = std::make_shared<at::Tensor>(torch::empty(
+                {static_cast<int64_t>(bytes)},
+                torch::TensorOptions().dtype(at::kByte).pinned_memory(true)));
+            return std::shared_ptr<void>(t, t->data_ptr());
+        };
+        ck_tile::stream_config prep_cfg{stream};
+        launcher.prepare_workspace_async(
+            workspace_ptr,
+            reinterpret_cast<const int*>(cu_seqlens_q.data_ptr()),
+            reinterpret_cast<const int*>(cu_seqlens_k.data_ptr()),
+            prep_cfg,
+            pinned_host_alloc);
     }
 
     at::Tensor dk_expanded, dv_expanded;


### PR DESCRIPTION
- [x] Depends on ROCm/rocm-libraries#7331
- [x] Stacked on #182

Adapts the FMHA BWD host wrappers to the new stream-async workspace prepare
API in CK PR #7331, eliminating the host-blocking ``cu_seqlens.cpu()`` D2H
sync that PR #182 had to perform on every group-mode bwd call.

## Changes

- **csrc/composable_kernel**: bump submodule to ``mono-split/users/yiding12/fmha-bwd-async-prepare`` HEAD.
- **csrc/flash_attn_ck/mha_bwd.cpp** / **mha_varlen_bwd.cpp**:
  - Replace ``launcher.prepare_workspace()`` with ``prepare_workspace_async()``,
    which enqueues the full workspace setup (dq_acc zero, group-mode D2H of
    seqstart, host-side metadata pack via ``hipLaunchHostFunc``, H2D back to
    device) on the caller's stream.
  - Pass a ``pinned_host_alloc`` lambda backed by PyTorch's
    ``CachingHostAllocator`` (``torch::empty(..., pin_memory=true)``). The
    launcher keeps the returned ``shared_ptr`` alive via a stream-tail
    ``hipLaunchHostFunc`` keepalive so the pinned buffer is not recycled
    while async copies are still in flight.
  - **mha_varlen_bwd** (group mode): drop the ``cu_seqlens_q.cpu()`` /
    ``cu_seqlens_k.cpu()`` host copies; the launcher now reads device seqstart
    directly via async D2H. ``get_ck_fmha_varlen_bwd_traits`` no longer takes
    ``seqstart_qs/ks``.

## Equivalence with aiter

This PR is the FA-side parallel of aiter PR ROCm/aiter#3150, just as #182 is
the FA-side parallel of aiter PR ROCm/aiter#2948.

## Validation

- ``pytest tests/test_flash_attn_ck.py`` on gfx950 with
  ``rocm/pytorch:rocm7.1.1_ubuntu24.04_py3.12_pytorch_release_2.9.1``:
  **260680 passed, 152076 skipped, 0 failed** (22:43)