### PR TITLE
[CK_TILE] Update CK and enable RDNA backward

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ FlashAttention-2 ROCm CK backend currently supports:
 1. MI200x, MI250x, MI300x, MI355x, and RDNA 3/4 GPUs.
 2. Datatype fp16 and bf16
 3. Both forward's and backward's head dimensions up to 256.
-4. RDNA 3 GPUs do not currently support backward, and RDNA 4 GPUs support backward only with deterministic=False
 
 #### Triton Backend
 The Triton implementation of [Flash Attention](https://tridao.me/publications/flash2/flash2.pdf) supports AMD's CDNA (MI200, MI300) and RDNA GPUs using fp16, bf16, and fp32 datatypes. It provides forward and backward passes with causal masking, variable sequence lengths, arbitrary Q/KV sequence lengths and head sizes, MQA/GQA, dropout, rotary embeddings, ALiBi, paged attention, and FP8 (via the Flash Attention v3 interface). Sliding window attention is currently a work in progress.

--- a/csrc/flash_attn_ck/flash_common.hpp
+++ b/csrc/flash_attn_ck/flash_common.hpp
@@ -78,46 +78,4 @@ inline int num_splits_heuristic_ck(int batch_nheads_mblocks, int num_SMs, int nu
 
 int override_num_splits_if_necessary(int batch, int nhead, int max_seqlen_q, int hdim_v, float p_drop, int num_splits);
 
-inline std::string get_gcn_arch_name() {
-#ifdef USE_ROCM
-    int dev = 0;
-    if (hipGetDevice(&dev) != hipSuccess) {
-        return std::string{};
-    }
-    hipDeviceProp_t prop{};
-    if (hipGetDeviceProperties(&prop, dev) != hipSuccess) {
-        return std::string{};
-    }
-    return std::string{prop.gcnArchName};
-#else
-    return "";
-#endif
-}
-
-inline bool is_gfx11_arch() {
-    const std::string arch = get_gcn_arch_name();
-    return !arch.empty() && arch.rfind("gfx11", 0) == 0;
-}
-
-inline bool is_gfx12_arch() {
-    const std::string arch = get_gcn_arch_name();
-    return !arch.empty() && arch.rfind("gfx12", 0) == 0;
-}
-
-inline bool is_gfx1x_arch() {
-    return is_gfx11_arch() || is_gfx12_arch();
-}
-
-inline void check_gfx1x_bwd_supported(bool deterministic) {
-    if (is_gfx11_arch()) {
-        TORCH_CHECK(false, "CK backward is not supported on gfx11.");
-    }
-
-    if (is_gfx12_arch() && deterministic) {
-        TORCH_CHECK(false,
-                    "Deterministic CK backward is not supported on gfx12. "
-                    "Please rerun with deterministic=False.");
-    }
-}
-
 } // namespace flash

--- a/csrc/flash_attn_ck/mha_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_bwd.cpp
@@ -337,9 +337,6 @@ mha_bwd(const at::Tensor &dout,                   // batch_size x seqlen_q x num
     at::cuda::CUDAGuard device_guard{q.device()};
 
     auto opts = q.options();
-    if (flash::is_gfx1x_arch()) {
-        flash::check_gfx1x_bwd_supported(deterministic);
-    }
     auto softmax_d = torch::empty({batch_size, num_heads, seqlen_q}, opts.dtype(at::kFloat));
 
     // Allocate device workspace

--- a/csrc/flash_attn_ck/mha_varlen_bwd.cpp
+++ b/csrc/flash_attn_ck/mha_varlen_bwd.cpp
@@ -354,9 +354,6 @@ mha_varlen_bwd(const at::Tensor &dout,                   // total_q x num_heads 
     at::cuda::CUDAGuard device_guard{q.device()};
 
     auto opts = q.options();
-    if (flash::is_gfx1x_arch()) {
-        flash::check_gfx1x_bwd_supported(deterministic);
-    }
     auto softmax_d = torch::empty({batch_size, num_heads, max_seqlen_q}, opts.dtype(at::kFloat));
 
     // Allocate device workspace

--- a/setup.py
+++ b/setup.py
@@ -192,9 +192,23 @@ def append_nvcc_threads(nvcc_extra_args):
     return nvcc_extra_args + ["--threads", NVCC_THREADS]
 
 
-def rename_cpp_to_cu(cpp_files):
+def rename_cpp_to_cu(cpp_files, generated_rdna_bfloat16_override=None):
     for entry in cpp_files:
-        shutil.copy(entry, os.path.splitext(entry)[0] + ".cu")
+        dst = os.path.splitext(entry)[0] + ".cu"
+        if (
+            generated_rdna_bfloat16_override is not None
+            and Path(entry).parent.name == "build"
+            and Path(entry).name.startswith(("fmha_fwd", "fmha_bwd"))
+            and re.search(r"_gfx1[12][^/]*\.cpp$", Path(entry).name)
+        ):
+            with open(entry, "r", encoding="utf-8") as src, open(dst, "w", encoding="utf-8") as out:
+                out.write(
+                    "#undef CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT\n"
+                    f"#define CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT {generated_rdna_bfloat16_override}\n"
+                )
+                out.write(src.read())
+        else:
+            shutil.copy(entry, dst)
 
 
 def validate_and_update_archs(archs):
@@ -211,6 +225,27 @@ def validate_and_update_archs(archs):
             f"'native' cannot be combined with explicit archs: {archs}. "
             "Use either GPU_ARCHS='native' or GPU_ARCHS='gfx942;gfx950'."
         )
+
+
+def get_ck_tile_bfloat16_supported_modes(ck_dir):
+    config_path = Path(this_dir) / ck_dir / "include" / "ck_tile" / "core" / "config.hpp"
+    try:
+        config_text = config_path.read_text(encoding="utf-8")
+    except OSError:
+        # Old vendored CK revisions support up to mode 4.
+        return {"0", "1", "2", "3", "4"}
+
+    supported_modes = set(
+        re.findall(
+            r"^#define\s+CK_TILE_FLOAT_TO_BFLOAT16_[A-Z0-9_]+\s+(\d+)\s*$",
+            config_text,
+            re.MULTILINE,
+        )
+    )
+    if not supported_modes:
+        raise RuntimeError(f"Failed to detect CK tile BF16 conversion modes from {config_path}.")
+
+    return supported_modes
 
 
 cmdclass = {}
@@ -465,16 +500,6 @@ elif not SKIP_CUDA_BUILD and IS_ROCM:
         if detect_hipify_v2():
             maybe_hipify_v2_flag = ["-DHIPIFY_V2"]
 
-        rename_cpp_to_cu(sources)
-
-        renamed_sources = ["csrc/flash_attn_ck/flash_api.cu",
-                        "csrc/flash_attn_ck/flash_common.cu",
-                        "csrc/flash_attn_ck/mha_bwd.cu",
-                        "csrc/flash_attn_ck/mha_fwd_kvcache.cu",
-                        "csrc/flash_attn_ck/mha_fwd.cu",
-                        "csrc/flash_attn_ck/mha_varlen_bwd.cu",
-                        "csrc/flash_attn_ck/mha_varlen_fwd.cu"] + glob.glob(f"build/fmha_*wd*.cu")
-
         cc_flag += ["-O3","-std=c++20",
                     "-Wno-unknown-warning-option",
                     "-fbracket-depth=1024",
@@ -492,11 +517,30 @@ elif not SKIP_CUDA_BUILD and IS_ROCM:
                     # "-DFLASHATTENTION_DISABLE_BACKWARD",
                     "-D__HIP_PLATFORM_HCC__=1"]
 
+        supported_ck_tile_bfloat16_modes = get_ck_tile_bfloat16_supported_modes(ck_dir)
+        has_gfx11_or_gfx12_target = any(
+            arch.startswith(("gfx11", "gfx12")) for arch in kernel_targets
+        )
+        rdna_bfloat16_default = "5" if "5" in supported_ck_tile_bfloat16_modes else "0"
+
         ck_tile_float_to_bfloat16_default = os.environ.get("CK_TILE_FLOAT_TO_BFLOAT16_DEFAULT")
         if ck_tile_float_to_bfloat16_default is None:
-            has_gfx11_target = any(arch.startswith("gfx11") for arch in kernel_targets)
-            ck_tile_float_to_bfloat16_default = "0" if has_gfx11_target else "3"
+            ck_tile_float_to_bfloat16_default = "3"
+
+        generated_rdna_bfloat16_override = None
+        if has_gfx11_or_gfx12_target:
+            generated_rdna_bfloat16_override = rdna_bfloat16_default
         cc_flag += [f"-DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT={ck_tile_float_to_bfloat16_default}"]
+
+        rename_cpp_to_cu(sources, generated_rdna_bfloat16_override=generated_rdna_bfloat16_override)
+
+        renamed_sources = ["csrc/flash_attn_ck/flash_api.cu",
+                        "csrc/flash_attn_ck/flash_common.cu",
+                        "csrc/flash_attn_ck/mha_bwd.cu",
+                        "csrc/flash_attn_ck/mha_fwd_kvcache.cu",
+                        "csrc/flash_attn_ck/mha_fwd.cu",
+                        "csrc/flash_attn_ck/mha_varlen_bwd.cu",
+                        "csrc/flash_attn_ck/mha_varlen_fwd.cu"] + glob.glob(f"build/fmha_*wd*.cu")
 
         # Imitate https://github.com/ROCm/composable_kernel/blob/c8b6b64240e840a7decf76dfaa13c37da5294c4a/CMakeLists.txt#L190-L214
         hip_version = get_hip_version()

--- a/tests/test_flash_attn_ck.py
+++ b/tests/test_flash_attn_ck.py
@@ -28,30 +28,6 @@ from test_flash_attn import (
 from flash_attn.layers.rotary import apply_rotary_emb
 
 
-def is_gfx11(device="cuda"):
-    if not torch.cuda.is_available():
-        return False
-    props = torch.cuda.get_device_properties(device)
-    name = (getattr(props, "gcnArchName", "") or getattr(props, "name", "")).lower()
-    return "gfx11" in name
-
-
-def is_gfx12(device="cuda"):
-    if not torch.cuda.is_available():
-        return False
-    props = torch.cuda.get_device_properties(device)
-    name = (getattr(props, "gcnArchName", "") or getattr(props, "name", "")).lower()
-    return "gfx12" in name
-
-
-def is_gfx1x(device="cuda"):
-    if not torch.cuda.is_available():
-        return False
-    props = torch.cuda.get_device_properties(device)
-    name = (getattr(props, "gcnArchName", "") or getattr(props, "name", "")).lower()
-    return ("gfx11" in name) or ("gfx12" in name)
-
-
 def is_bwd_hdim_supported(d):
     return d <= 256
 
@@ -60,24 +36,12 @@ def is_bwd_supported(d, deterministic):
     if not is_bwd_hdim_supported(d):
         return False
 
-    if is_gfx11():
-        return False
-
-    if is_gfx12() and deterministic:
-        return False
-
     return True
 
 
 def get_bwd_unsupported_reason(d, deterministic):
     if is_bwd_hdim_supported(d) is False:
         return f"CK backward is not supported for head dim {d}."
-
-    if is_gfx11():
-        return "CK backward is not supported on gfx11."
-
-    if is_gfx12() and deterministic:
-        return "Deterministic CK backward is not supported on gfx12."
 
     return "CK backward is not supported on this arch/configuration."
 


### PR DESCRIPTION
## Motivation

Enable FlashAttention CK backward support on RDNA GPUs and pick up RDNA FMHA performance improvements from CK.

The updated CK revision includes the fixes needed for gfx11/gfx12 backward support, along with optimizations for RDNA BF16 conversion, padded head dimensions, and generated FMHA kernel coverage.

## Technical Details

- Updated the `composable_kernel` submodule to pick up RDNA FMHA fixes and optimizations.
- Removed local gfx11/gfx12 CK backward guards from the FlashAttention CK wrapper.
- Removed RDNA backward skips from the CK test coverage.
- Updated the CK build path to select an RDNA-compatible BF16 conversion mode for generated RDNA FMHA blobs.

## Test Plan

pytest -q -s tests/test_flash_attn_ck.py

## Test Result

Tested on gfx1100/gfx1201/gfx942
Result: all passed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
